### PR TITLE
Convert Generate_ASCII_Artwork to GitHub Actions

### DIFF
--- a/.github/workflows/generate_ascii_artwork.yml
+++ b/.github/workflows/generate_ascii_artwork.yml
@@ -1,0 +1,28 @@
+name: Generate_ASCII_Artwork
+on:
+  workflow_dispatch:
+env:
+  m_username: "${{ secrets.MONGO_DB_USERNAME_M_USERNAME }}"
+#   # TimestamperBuildWrapper was not converted because the behavior is available by default in GitHub Actions and/or it is not configurable
+jobs:
+  build:
+    runs-on:
+      - ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4.1.0
+    - name: run command
+      shell: bash
+      run: |-
+        # Build a message by invoking ADVICESLIP API
+        curl -s https://api.adviceslip.com/advice > advice.json
+        cat advice.json
+        # Test to make sure the advice message has more than 5 words.
+        cat advice.json | jq -r .slip.advice > advice.message
+        [ $(wc -w < advice.message) -gt 5 ] && echo "Advice has more than 5 words" || (echo "Advice - $(cat advice.message)  has 5 words or less" && exit 1)
+        # Deploy
+        echo $m_username
+        sudo apt-get install cowsay -y
+        echo $PATH
+        export PATH="$PATH:/usr/games:/usr/local/games"
+        cat advice.message | cowsay -f $(ls /usr/share/cowsay/cows | shuf -n 1)


### PR DESCRIPTION
Pipeline migrated from [Jenkins](http://139.84.149.83:8080/job/Generate%20ASCII%20Artwork/) :tada:

## Manual steps

Perform the following steps to complete the migration:

### Generate ASCII Artwork
- [ ] Ensure secret is available: `${{ secrets.MONGO_DB_USERNAME_M_USERNAME }}`